### PR TITLE
Revert to older firebase-tools. new one cannot deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN apk --no-cache add --virtual native-deps python git make gcc g++ openssl-dev
   && cd .. \
   && rm -rf git-crypt \
   && yarn config set spin false \
-  && yarn global add firebase-tools@4.2.1 phantomjs-prebuilt grpc node-pre-gyp node-gyp \
+  && yarn global add firebase-tools@4.1.2 phantomjs-prebuilt grpc node-pre-gyp node-gyp \
   && yarn cache clean \
   && apk del make gcc g++ openssl-dev


### PR DESCRIPTION
https://github.com/firebase/firebase-tools/issues/906

```
=== Deploying to 'ammolytics-blog'...

i  deploying hosting
i  hosting[ammolytics-blog]: beginning deploy...
i  hosting[ammolytics-blog]: found 0 files in _site
✔  hosting[ammolytics-blog]: file upload complete
i  hosting[ammolytics-blog]: finalizing version...
(node:9) UnhandledPromiseRejectionWarning: Error
    at new FirebaseError (/usr/local/share/.config/yarn/global/node_modules/firebase-tools/lib/error.js:11:16)
    at Object.reject (/usr/local/share/.config/yarn/global/node_modules/firebase-tools/lib/utils.js:135:27)
    at /usr/local/share/.config/yarn/global/node_modules/firebase-tools/lib/deploy/hosting/prepare.js:58:20
    at arrayEach (/usr/local/share/.config/yarn/global/node_modules/lodash/lodash.js:516:11)
    at Function.forEach (/usr/local/share/.config/yarn/global/node_modules/lodash/lodash.js:9344:14)
    at module.exports (/usr/local/share/.config/yarn/global/node_modules/firebase-tools/lib/deploy/hosting/prepare.js:37:5)
    at _chain (/usr/local/share/.config/yarn/global/node_modules/firebase-tools/lib/deploy/index.js:26:38)
    at /usr/local/share/.config/yarn/global/node_modules/firebase-tools/lib/deploy/index.js:83:14
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:229:7)
(node:9) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:9) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

Error: HTTP Error: 404, Not Found
```